### PR TITLE
Add markdown templates for upstream preparation.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Report a bug to help us improve the Load Balancer Operator for Kubernetes
+---
+
+**Bug description**
+
+**Affected product area (please put an X in all that apply)**
+
+- [ ] Docs
+- [ ] Installation
+- [ ] Plugin
+- [ ] Security
+- [ ] Test and Release
+- [ ] User Experience
+
+**Expected behavior**
+
+**Steps to reproduce the bug**
+
+**Version** (include the SHA if the version is not obvious)
+
+**Environment where the bug was observed (cloud, OS, etc)**
+
+**Relevant Debug Output (Logs, manifests, etc)**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea to improve the Load Balancer Operator for Kubernetes
+---
+(This is used to request new product features)
+
+**Describe the feature request**
+
+**Describe alternatives you've considered**
+
+**Affected product area (please put an X in all that apply)**
+
+- [ ] Docs
+- [ ] Installation
+- [ ] Plugin
+- [ ] Security
+- [ ] Test and Release
+- [ ] User Experience
+
+**Additional context**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,11 +13,13 @@ Example: Created vSphere workload cluster to verify change.
 
 **Special notes for your reviewer**:
 
-**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
+**Release note**:
 <!--
-If no, just write "NONE" in the release-note block below.
-If yes, a release note is required:
-Enter your extended release note in the block below.
+See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
+for more details.
+
+Please add a short text in the release-note block below (or "NONE" if not applicable)
+if there is anything in this PR that is worthy of mention in the next release.
 -->
 ```release-note
 

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,31 @@
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+<!--
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+-->
+Fixes #
+
+**Describe testing done for PR**:
+<!--
+Example: Created vSphere workload cluster to verify change.
+-->
+
+**Special notes for your reviewer**:
+
+**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
+<!--
+If no, just write "NONE" in the release-note block below.
+If yes, a release note is required:
+Enter your extended release note in the block below.
+-->
+```release-note
+
+```
+**New PR Checklist**
+
+- [ ] Ensure PR contains only public links or terms
+- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
+- [ ] Squash the commits in this branch before merge to preserve our git history
+- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
+- [ ] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Use this file to ensure that changed code is reviewed by the owners of the changed files
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners


### PR DESCRIPTION
Use this thread to discuss upstream templating, including

1. PR templates
2. Issue templates
3. Labels/Milestones
4. CODEOWNER
5. Other documents to make potential outside contributors can easily ramp up
6. Bots / Automations