### PR TITLE
Fix labeler.yml not found.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,9 @@
+github-cicd:
+  - .github/**/*
+
+docs:
+  - docs/**/*
+
+config:
+  - config/**/*
+

--- a/.github/workflows/pr-labelers.yml
+++ b/.github/workflows/pr-labelers.yml
@@ -6,6 +6,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@main
+      - uses: actions/labeler@v3
         with:
           repo-token: "${{ secrets.BOT_GITHUB_TOKEN }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

The labeler workflow is supposed to label every PRs by checking the files they modifies. This PR adds .github/labeler.yml and fixes the labeler error. 

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ x] Ensure PR contains only public links or terms
- [ x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ x] Squash the commits in this branch before merge to preserve our git history
- [ x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.