### PR TITLE
fix workloadcluster deletion

### DIFF
--- a/controllers/akodeploymentconfig/cluster/cluster_controller.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller.go
@@ -5,8 +5,9 @@ package cluster
 
 import (
 	"context"
-	"k8s.io/client-go/kubernetes/scheme"
 	"time"
+
+	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -132,9 +133,8 @@ func (r *ClusterReconciler) cleanup(
 		return false, err
 	}
 
-	akoSetting := values.LoadBalancerAndIngressService.Config.AKOSettings
-	if akoSetting.DeleteConfig != "true" {
-		akoSetting.DeleteConfig = "true"
+	if values.LoadBalancerAndIngressService.Config.AKOSettings.DeleteConfig != "true" {
+		values.LoadBalancerAndIngressService.Config.AKOSettings.DeleteConfig = "true"
 		secretData, err := values.YttYaml()
 		if err != nil {
 			return false, errors.Errorf("workload cluster %s ako add-on data values marshal error", obj.Name)

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
@@ -187,6 +187,25 @@ func unitTestAKODeploymentYaml() {
 				Expect(err).Should(HaveOccurred())
 				akoDeploymentConfig.Spec.DataNetwork.CIDR = "10.0.0.0/24"
 			})
+
+			It("should expose a bug that we cannot update delete_config in this way", func() {
+				values, err := ako.NewValues(akoDeploymentConfig, "namespace-name")
+				Expect(err).ShouldNot(HaveOccurred())
+				akoSetting := values.LoadBalancerAndIngressService.Config.AKOSettings
+				akoSetting.DeleteConfig = "true"
+				secretData, err := values.YttYaml()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(secretData).Should(ContainSubstring("delete_config: \"false\""))
+			})
+
+			It("should update delete_config in this way", func() {
+				values, err := ako.NewValues(akoDeploymentConfig, "namespace-name")
+				Expect(err).ShouldNot(HaveOccurred())
+				values.LoadBalancerAndIngressService.Config.AKOSettings.DeleteConfig = "true"
+				secretData, err := values.YttYaml()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(secretData).Should(ContainSubstring("delete_config: \"true\""))
+			})
 		})
 	})
 }

--- a/pkg/ako/values_test.go
+++ b/pkg/ako/values_test.go
@@ -5,8 +5,9 @@ package ako
 
 import (
 	"encoding/json"
-	"k8s.io/utils/pointer"
 	"strconv"
+
+	"k8s.io/utils/pointer"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

Fix workload cluster deletion stuck issue. Since we refactored `values` struct, we need to change this to make the deletion successful.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.