### PR TITLE
Fix adding usable network error

### DIFF
--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
@@ -239,14 +239,14 @@ func (r *AKODeploymentConfigReconciler) reconcileCloudUsableNetwork(
 	// Ensure network is added to the cloud's IPAM Profile as one of its
 	// usable Networks
 	var foundUsableNetwork bool
-	for _, net := range ipam.InternalProfile.UsableNetworkRefs {
-		if net == *(network.URL) {
+	for _, net := range ipam.InternalProfile.UsableNetworks {
+		if *net.NwRef == *(network.URL) {
 			foundUsableNetwork = true
 			break
 		}
 	}
 	if !foundUsableNetwork {
-		ipam.InternalProfile.UsableNetworkRefs = append(ipam.InternalProfile.UsableNetworkRefs, *(network.URL))
+		ipam.InternalProfile.UsableNetworks = append(ipam.InternalProfile.UsableNetworks, &models.IPAMUsableNetwork{NwRef: network.URL})
 		_, err := r.aviClient.IPAMDNSProviderProfileUpdate(ipam)
 		if err != nil {
 			log.Error(err, "Failed to add usable network", "network", network.Name)

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_intg_test.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_intg_test.go
@@ -238,7 +238,7 @@ func intgTestAkoDeploymentConfigController() {
 		ctx.AviClient.IPAMDNSProviderProfile.SetGetIPAMFunc(func(uuid string, options ...session.ApiOptionsParams) (*models.IPAMDNSProviderProfile, error) {
 			res := &models.IPAMDNSProviderProfile{
 				InternalProfile: &models.IPAMDNSInternalProfile{
-					UsableNetworkRefs: []string{"10.0.0.1"},
+					UsableNetworks: []*models.IPAMUsableNetwork{{NwRef: pointer.StringPtr("10.0.0.1")}},
 				},
 			}
 			return res, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix `load-balancer-operator` keeps complaining about: `Failed to add usable network`

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.