### PR TITLE
Fix avi as control plane ha bootstrap cluster error

### DIFF
--- a/pkg/haprovider/haprovider.go
+++ b/pkg/haprovider/haprovider.go
@@ -134,11 +134,16 @@ func (r *HAProvider) annotateService(ctx context.Context, cluster *clusterv1.Clu
 		akoov1alpha1.TKGClusterNameSpaceLabel: cluster.Namespace,
 	}
 
+	if ako_operator.IsBootStrapCluster() {
+		return serviceAnnotation, nil
+	}
+
 	aviInfraSetting, err := r.getAviInfraSettingFromCluster(ctx, cluster)
 	if err != nil {
 		return serviceAnnotation, err
 	}
-	if aviInfraSetting != nil && !ako_operator.IsBootStrapCluster() {
+
+	if aviInfraSetting != nil {
 		// add AVIInfraSetting annotation when creating HA svc
 		serviceAnnotation[akoov1alpha1.HAAVIInfraSettingAnnotationsKey] = aviInfraSetting.Name
 	}


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

- When using AVI to provide control plane VIP, need to exclude `AKODeploymentConfig` reconcile.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.