### PR TITLE
Fix incorrect apiVersion for kind cluster config.

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -64,7 +64,8 @@ EOF
 
 # If KIND_MINIMUM_VERSION is empty or unset, use "tkg-lcp"
 KIND_MANAGEMENT_CLUSTER="${KIND_MANAGEMENT_CLUSTER:-tkg-lcp}"
-CAPI_VERSION="v0.3.10"
+CAPI_VERSION="v1.0.0"
+
 # Runtime setup
 # By default do not skip anything.
 SKIP_CAPD_IMAGE_LOAD="${SKIP_CAPD_IMAGE_LOAD:-}"

--- a/hack/kind/kind-cluster-with-extramounts.yaml
+++ b/hack/kind/kind-cluster-with-extramounts.yaml
@@ -1,5 +1,5 @@
 kind: Cluster
-apiVersion: kind.x-k8s.io/v1beta1
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
   extraMounts:


### PR DESCRIPTION
**What this PR does / why we need it**:

Just realize some of the e2e testing scripts are broken before I try to add some documentations. This PR fixes the incorrect apiVersion inside the file `kind-cluster-with-extramounts.yaml`.

Currently, there is no `v1beta1` for kind config now. https://github.com/kubernetes-sigs/kind/blob/main/pkg/apis/config/v1alpha4/types.go

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Passed upstream github CI

`./hack/e2e.sh -u` will no longer throw error that `Cluster` not found in `kind.x-k8s.io/v1beta1`

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.