### PR TITLE
Adapt ako's fix for avi resource deletion in k8s 1.22

### DIFF
--- a/pkg/ako/ako.go
+++ b/pkg/ako/ako.go
@@ -11,14 +11,15 @@ import (
 	"github.com/go-logr/logr"
 	akoov1alpha1 "github.com/vmware-samples/load-balancer-operator-for-kubernetes/api/v1alpha1"
 	appv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	akoStatefulSetName = "ako"
-	akoConditionType   = appv1.StatefulSetConditionType("ako.vmware.com/ObjectDeletionInProgress")
+	akoStatefulSetName         = "ako"
+	akoCleanUpAnnotationKey    = "AviObjectDeletionStatus"
+	akoCleanUpInProgressStatus = "Started"
+	akoCleanUpFinishedStatus   = "Done"
 )
 
 func CleanupFinished(ctx context.Context, remoteClient client.Client, log logr.Logger) (bool, error) {
@@ -36,14 +37,5 @@ func CleanupFinished(ctx context.Context, remoteClient client.Client, log logr.L
 		return false, err
 	}
 
-	return conditionHasStatus(ss.Status.Conditions, akoConditionType, corev1.ConditionFalse), nil
-}
-
-func conditionHasStatus(conditions []appv1.StatefulSetCondition, ctype appv1.StatefulSetConditionType, status corev1.ConditionStatus) bool {
-	for _, c := range conditions {
-		if c.Type == ctype && c.Status == status {
-			return true
-		}
-	}
-	return false
+	return ss.Annotations[akoCleanUpAnnotationKey] == akoCleanUpFinishedStatus, nil
 }

--- a/pkg/ako/ako_test.go
+++ b/pkg/ako/ako_test.go
@@ -14,7 +14,6 @@ import (
 
 	akoov1alpha1 "github.com/vmware-samples/load-balancer-operator-for-kubernetes/api/v1alpha1"
 	appv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -73,13 +72,8 @@ var _ = Describe("AKO", func() {
 	})
 	When("InProgress status is True", func() {
 		BeforeEach(func() {
-			ss.Status = appv1.StatefulSetStatus{
-				Conditions: []appv1.StatefulSetCondition{
-					{
-						Type:   akoConditionType,
-						Status: corev1.ConditionTrue,
-					},
-				},
+			ss.Annotations = map[string]string{
+				akoCleanUpAnnotationKey: akoCleanUpInProgressStatus,
 			}
 		})
 		It("should not claim finished", func() {
@@ -89,13 +83,8 @@ var _ = Describe("AKO", func() {
 	})
 	When("InProgress status is False", func() {
 		BeforeEach(func() {
-			ss.Status = appv1.StatefulSetStatus{
-				Conditions: []appv1.StatefulSetCondition{
-					{
-						Type:   akoConditionType,
-						Status: corev1.ConditionFalse,
-					},
-				},
+			ss.Annotations = map[string]string{
+				akoCleanUpAnnotationKey: akoCleanUpFinishedStatus,
 			}
 		})
 		It("should claim finished", func() {


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

Adapt AKO's fix to use annotations to show the resources deletion status in k8s 1.22

See this: vmware/load-balancer-and-ingress-services-for-kubernetes#688 for details.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.

/kind bug