### PR TITLE
Fix control plane initialization bugs: ako-operator manager doesn't reconcile useable network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ integration-test: $(GINKGO) $(ETCD)
 	$(GINKGO) -v controllers/akodeploymentconfig -- -enable-integration-tests -enable-unit-tests=false
 	$(GINKGO) -v controllers/machine -- -enable-integration-tests -enable-unit-tests=false
 	$(GINKGO) -v controllers/cluster -- -enable-integration-tests -enable-unit-tests=false
+	$(GINKGO) -v controllers/configmap -- -enable-integration-tests -enable-unit-tests=false
 
 .PHONY: kind-e2e-test
 kind-e2e-test: $(KUSTOMIZE) $(KIND) $(KUBECTL) $(JQ) $(YTT)

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -22,12 +22,15 @@ const (
 
 	ManagementClusterAkoDeploymentConfig = "install-ako-for-management-cluster"
 
-	AkoUserRoleName              = "ako-essential-role"
-	ClusterFinalizer             = "ako-operator.networking.tkg.tanzu.vmware.com"
-	AkoDeploymentConfigFinalizer = "ako-operator.networking.tkg.tanzu.vmware.com"
-	AkoDeploymentConfigKind      = "AKODeploymentConfig"
-	AkoDeploymentConfigVersion   = "networking.tanzu.vmware.com/v1alpha1"
-	AkoStatefulSetName           = "ako"
+	AkoUserRoleName               = "ako-essential-role"
+	ClusterFinalizer              = "ako-operator.networking.tkg.tanzu.vmware.com"
+	AkoDeploymentConfigFinalizer  = "ako-operator.networking.tkg.tanzu.vmware.com"
+	AkoDeploymentConfigKind       = "AKODeploymentConfig"
+	AkoDeploymentConfigVersion    = "networking.tanzu.vmware.com/v1alpha1"
+	AkoStatefulSetName            = "ako"
+	AkoConfigMapName              = "avi-k8s-config"
+	AkoConfigMapCloudNameKey      = "cloudName"
+	AkoConfigMapVipNetworkListKey = "vipNetworkList"
 
 	AVI_VERSION                                                  = "20.1.3"
 	AviClusterLabel                                              = "networking.tkg.tanzu.vmware.com/avi"

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller.go
@@ -5,6 +5,7 @@ package akodeploymentconfig
 
 import (
 	"context"
+	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/netprovider"
 
 	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/controllers/akodeploymentconfig/cluster"
 	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/controllers/akodeploymentconfig/phases"
@@ -48,6 +49,7 @@ type AKODeploymentConfigReconciler struct {
 	Scheme            *runtime.Scheme
 	userReconciler    *user.AkoUserReconciler
 	ClusterReconciler *cluster.ClusterReconciler
+	netprovider.UsableNetworkProvider
 }
 
 func (r *AKODeploymentConfigReconciler) SetAviClient(client aviclient.Client) {

--- a/controllers/configmap/configmap_controller.go
+++ b/controllers/configmap/configmap_controller.go
@@ -1,0 +1,101 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package configmap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/api/v1alpha1"
+	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/aviclient"
+	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/netprovider"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	corev1 "k8s.io/api/core/v1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SetupWithManager adds this reconciler to a new controller then to the
+// provided manager.
+func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		// Watch ConfigMap resources.
+		For(&corev1.ConfigMap{}).
+		Complete(r)
+}
+
+// ConfigMapReconciler reads the data network from avi-k8s-config ConfigMap and
+// accordingly adds it as a usable network via the AVI Controller client.
+type ConfigMapReconciler struct {
+	client.Client
+	aviClient aviclient.Client
+	Log       logr.Logger
+	Scheme    *runtime.Scheme
+	netprovider.UsableNetworkProvider
+}
+
+func (r *ConfigMapReconciler) SetAviClient(client aviclient.Client) {
+	r.aviClient = client
+}
+
+var InvalidAKOConfigMapErr = errors.New("Invalid format of AKO ConfigMap")
+
+func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+
+	log := r.Log.WithValues("ConfigMap", req.NamespacedName)
+
+	// Get the resource for this request.
+	cm := &corev1.ConfigMap{}
+	if err := r.Client.Get(ctx, req.NamespacedName, cm); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("ConfigMap not found, will not reconcile")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if cm.Name != v1alpha1.AkoConfigMapName || cm.Namespace != v1alpha1.TKGSystemNamespace {
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("Start reconciling AVI cloud usable network in bootstrap cluster")
+
+	cloudName, exist := cm.Data[v1alpha1.AkoConfigMapCloudNameKey]
+	if !exist {
+		log.Info("Key not found in ConfigMap: cloudName")
+		return ctrl.Result{}, InvalidAKOConfigMapErr
+	}
+	vipNetworkListRaw, exist := cm.Data[v1alpha1.AkoConfigMapVipNetworkListKey]
+	if !exist {
+		log.Info("Key not found in ConfigMap: vipNetworkList")
+		return ctrl.Result{}, InvalidAKOConfigMapErr
+	}
+
+	var vipNetworkList netprovider.UsableNetworks
+	if err := json.Unmarshal([]byte(vipNetworkListRaw), &vipNetworkList); err != nil {
+		log.Error(err, "Failed to unmarshal VIPNetworkList")
+		return ctrl.Result{}, err
+	}
+
+	log.V(5).Info(fmt.Sprintf("ConfigMap %s found in %s", v1alpha1.AkoConfigMapName, v1alpha1.TKGSystemNamespace))
+
+	for _, vipNetwork := range vipNetworkList {
+		added, err := r.AddUsableNetwork(r.aviClient, cloudName, vipNetwork.NetworkName)
+		if err != nil {
+			log.Error(err, "Failed to add usable network", vipNetwork.NetworkName)
+			return ctrl.Result{}, err
+		}
+		if added {
+			log.Info("Added Usable Network", vipNetwork.NetworkName)
+		} else {
+			log.Info("Network is already one of the cloud's usable network", vipNetwork.NetworkName)
+		}
+	}
+	return ctrl.Result{}, nil
+}

--- a/controllers/configmap/configmap_intg_test.go
+++ b/controllers/configmap/configmap_intg_test.go
@@ -1,0 +1,152 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package configmap_test
+
+import (
+	"fmt"
+	"github.com/avinetworks/sdk/go/models"
+	"github.com/avinetworks/sdk/go/session"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	testutil "github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/test/util"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+
+	ako_operator "github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/ako-operator"
+	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/test/builder"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+)
+
+func intgTestEnsureUsableNetworkAddedInBootstrapCluster() {
+
+	var (
+		ctx *builder.IntegrationTestContext
+
+		configMap                *corev1.ConfigMap
+		UpdateIPAMFnCalled       bool
+		UpdateIPAMUsableNetworks []*models.IPAMUsableNetwork
+	)
+
+	configMap = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "avi-k8s-config",
+			Namespace: "tkg-system",
+		},
+		Data: map[string]string{
+			"cloudName":      "Default Cloud 2",
+			"vipNetworkList": "[{\"networkName\":\"VM Network 2\",\"cidr\":\"10.168.176.0/20\"}]",
+		},
+	}
+
+	GetIPAMFuncWithUsableNetwork := func(uuid string, options ...session.ApiOptionsParams) (*models.IPAMDNSProviderProfile, error) {
+		res := &models.IPAMDNSProviderProfile{
+			InternalProfile: &models.IPAMDNSInternalProfile{
+				UsableNetworks: []*models.IPAMUsableNetwork{{NwRef: pointer.StringPtr("10.168.176.0")}},
+			},
+		}
+		return res, nil
+	}
+
+	GetIPAMFuncWithoutUsableNetwork := func(uuid string, options ...session.ApiOptionsParams) (*models.IPAMDNSProviderProfile, error) {
+		res := &models.IPAMDNSProviderProfile{
+			InternalProfile: &models.IPAMDNSInternalProfile{
+				UsableNetworks: []*models.IPAMUsableNetwork{},
+			},
+		}
+		return res, nil
+	}
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+
+		// reset assertion vars
+		UpdateIPAMFnCalled = false
+		UpdateIPAMUsableNetworks = []*models.IPAMUsableNetwork{}
+
+		// stub the NetworkGetByName of the avi client Network
+		ctx.AviClient.Network.SetGetByNameFn(func(name string, options ...session.ApiOptionsParams) (*models.Network, error) {
+			if name == "VM Network 2" {
+				return &models.Network{URL: pointer.StringPtr("10.168.176.0")}, nil
+			}
+			return nil, errors.New(fmt.Sprintf("%s network not found\n", name))
+		})
+
+		// stub the NetworkGetByName of the avi client Cloud
+		ctx.AviClient.Cloud.SetGetByNameCloudFunc(func(name string, options ...session.ApiOptionsParams) (*models.Cloud, error) {
+			if name == "Default Cloud 2" {
+				return &models.Cloud{
+					IPAMProviderRef: pointer.StringPtr("https://10.0.0.x/api/ipamdnsproviderprofile/ipamdnsproviderprofile-f08403a1-0dc7-4f13-bda3-0ba2fa476516"),
+				}, nil
+			}
+			return nil, errors.New(fmt.Sprintf("%s cloud not found\n", name))
+		})
+
+		ctx.AviClient.IPAMDNSProviderProfile.SetUpdateIPAMFn(func(obj *models.IPAMDNSProviderProfile, options ...session.ApiOptionsParams) (*models.IPAMDNSProviderProfile, error) {
+			UpdateIPAMFnCalled = true
+			UpdateIPAMUsableNetworks = obj.InternalProfile.UsableNetworks
+			return obj, nil
+		})
+
+		err := os.Setenv(ako_operator.IsControlPlaneHAProvider, "False")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		err = os.Setenv(ako_operator.DeployInBootstrapCluster, "True")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+	})
+
+	When("The network already exists in IPAM profile", func() {
+		BeforeEach(func() {
+
+			// stub the IPAMDNSProviderProfileGet of the avi client
+			ctx.AviClient.IPAMDNSProviderProfile.SetGetIPAMFunc(GetIPAMFuncWithUsableNetwork)
+			testutil.CreateObjects(ctx, configMap.DeepCopy())
+		})
+
+		AfterEach(func() {
+			testutil.DeleteObjects(ctx, configMap.DeepCopy())
+			testutil.EnsureRuntimeObjectMatchExpectation(ctx, client.ObjectKey{
+				Name:      "avi-k8s-config",
+				Namespace: "tkg-system",
+			}, &corev1.ConfigMap{}, testutil.NOTFOUND)
+		})
+
+		It("IPAM profile should not be updated", func() {
+			Consistently(func() bool {
+				return UpdateIPAMFnCalled == false
+			}, time.Second).Should(BeTrue())
+		})
+	})
+
+	When("The network does not exists in IPAM profile", func() {
+		BeforeEach(func() {
+			// stub the IPAMDNSProviderProfileGet of the avi client
+			ctx.AviClient.IPAMDNSProviderProfile.SetGetIPAMFunc(GetIPAMFuncWithoutUsableNetwork)
+			testutil.CreateObjects(ctx, configMap.DeepCopy())
+		})
+
+		AfterEach(func() {
+			testutil.DeleteObjects(ctx, configMap.DeepCopy())
+			testutil.EnsureRuntimeObjectMatchExpectation(ctx, client.ObjectKey{
+				Name:      "avi-k8s-config",
+				Namespace: "tkg-system",
+			}, &corev1.ConfigMap{}, testutil.NOTFOUND)
+		})
+
+		It("IPAM profile should be updated", func() {
+			Eventually(func() bool {
+				return UpdateIPAMFnCalled == true && len(UpdateIPAMUsableNetworks) == 1 &&
+					*UpdateIPAMUsableNetworks[0].NwRef == "10.168.176.0"
+			}).Should(BeTrue())
+		})
+	})
+}

--- a/controllers/configmap/suite_test.go
+++ b/controllers/configmap/suite_test.go
@@ -1,0 +1,74 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package configmap_test
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo"
+	akoov1alpha1 "github.com/vmware-samples/load-balancer-operator-for-kubernetes/api/v1alpha1"
+	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/controllers/configmap"
+	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/aviclient"
+	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/test/builder"
+	testutil "github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/test/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"path/filepath"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// suite is used for unit and integration testing this controller.
+var suite = builder.NewTestSuiteForController(
+	func(mgr ctrlmgr.Manager) error {
+		builder.FakeAvi = aviclient.NewFakeAviClient()
+		rec := &configmap.ConfigMapReconciler{
+			Client: mgr.GetClient(),
+			Log:    ctrl.Log.WithName("controllers").WithName("ConfigMap"),
+			Scheme: mgr.GetScheme(),
+		}
+		rec.SetAviClient(builder.FakeAvi)
+		if err := rec.SetupWithManager(mgr); err != nil {
+			return err
+		}
+
+		// always create a namespace tkg-system for testing
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "tkg-system"},
+		}
+		err := rec.Client.Create(context.Background(), namespace)
+		return err
+	},
+	func(scheme *runtime.Scheme) (err error) {
+		err = corev1.AddToScheme(scheme)
+		if err != nil {
+			return err
+		}
+		err = clusterv1.AddToScheme(scheme)
+		if err != nil {
+			return err
+		}
+		err = akoov1alpha1.AddToScheme(scheme)
+		return err
+	},
+	filepath.Join(testutil.FindModuleDir("sigs.k8s.io/cluster-api"), "config", "crd", "bases"),
+)
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)
+
+func TestController(t *testing.T) {
+	suite.Register(t, "AKO Operator Cluster Controller", intgTests, unitTests)
+}
+
+func intgTests() {
+	Describe("ClusterController Test", intgTestEnsureUsableNetworkAddedInBootstrapCluster)
+}
+
+func unitTests() {
+}

--- a/pkg/netprovider/network_provider.go
+++ b/pkg/netprovider/network_provider.go
@@ -1,0 +1,56 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package netprovider
+
+import (
+	"github.com/avinetworks/sdk/go/models"
+	"github.com/pkg/errors"
+	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/aviclient"
+)
+
+type UsableNetworks []UsableNetwork
+
+type UsableNetwork struct {
+	NetworkName string `json:"networkName"`
+	CIDR        string `json:"cidr"`
+}
+
+type UsableNetworkProvider struct{}
+
+func (c *UsableNetworkProvider) AddUsableNetwork(client aviclient.Client, cloudName, networkName string) (bool, error) {
+	network, err := client.NetworkGetByName(networkName)
+	if err != nil {
+		return false, errors.Wrapf(err, "Failed to get Data Network %s from AVI Controller\n", networkName)
+	}
+	cloud, err := client.CloudGetByName(cloudName)
+	if err != nil {
+		// Cannot find the configured cloud, requeue the request but
+		// leave enough time for operators to resolve this issue
+		return false, errors.Wrapf(err, "Failed to find cloud %s, requeue the request\n", cloudName)
+	}
+	if cloud.IPAMProviderRef == nil {
+		// Cannot find any configured IPAM Provider, requeue the request but
+		// leave enough time for operators to resolve this issue
+		return false, errors.Wrap(err, "No IPAM Provider is registered for the cloud, requeue the request")
+	}
+	ipamProviderUUID := aviclient.GetUUIDFromRef(*(cloud.IPAMProviderRef))
+	ipam, err := client.IPAMDNSProviderProfileGet(ipamProviderUUID)
+	if err != nil {
+		return false, errors.Wrap(err, "Failed to find IPAM profile")
+	}
+
+	// Ensure network is added to the cloud's IPAM Profile as one of its
+	// usable Networks
+	for _, usableNetwork := range ipam.InternalProfile.UsableNetworks {
+		if *usableNetwork.NwRef == *(network.URL) {
+			return false, nil
+		}
+	}
+	ipam.InternalProfile.UsableNetworks = append(ipam.InternalProfile.UsableNetworks, &models.IPAMUsableNetwork{NwRef: network.URL})
+	_, err = client.IPAMDNSProviderProfileUpdate(ipam)
+	if err != nil {
+		return false, errors.Wrapf(err, "Failed to add usable network %s\n", *network.Name)
+	}
+	return true, nil
+}

--- a/pkg/test/util/utils.go
+++ b/pkg/test/util/utils.go
@@ -5,16 +5,14 @@ package util
 
 import (
 	"encoding/json"
-	"os/exec"
-
 	. "github.com/onsi/gomega"
+	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/test/builder"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog"
+	"os/exec"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/test/builder"
-	"k8s.io/klog"
 )
 
 type ExpectResult int
@@ -73,6 +71,9 @@ func ensureRuntimeObjectCreated(ctx *builder.IntegrationTestContext, o client.Ob
 		EnsureRuntimeObjectMatchExpectation(ctx, client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}, obj, EXIST)
 	case *capi.Cluster:
 		obj = o.(*capi.Cluster)
+		EnsureRuntimeObjectMatchExpectation(ctx, client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}, obj, EXIST)
+	case *corev1.ConfigMap:
+		obj = o.(*corev1.ConfigMap)
 		EnsureRuntimeObjectMatchExpectation(ctx, client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}, obj, EXIST)
 	default:
 		klog.Fatal("Unknown type object")


### PR DESCRIPTION
**What this PR does / why we need it**:

In the bootstrap cluster, we no longer deploy any AKODeploymentConfig since [this PR](https://github.com/vmware-tanzu/tanzu-framework/pull/821) even when AVI as HA provider. However, the ako-operator manager relies on this ADC to reconcile usable network and add it to IPAM on the AVI controller. This will cause the management cluster generation to be stucked at

`cluster control plane is still being initialized: WaitingForKubeadmInit, retrying`

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # None

The fix involves reconcile against a ConfigMap named `avi-k8s-config` if and only if the ako-operator is in the bootstrap cluster and AVI as HA is enabled.

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
E2E tests for this fix are done.


**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.