### PR TITLE
[WIP] Handle avi resource deletion timeout

### DIFF
--- a/pkg/ako/ako.go
+++ b/pkg/ako/ako.go
@@ -20,6 +20,7 @@ const (
 	akoCleanUpAnnotationKey    = "AviObjectDeletionStatus"
 	akoCleanUpInProgressStatus = "Started"
 	akoCleanUpFinishedStatus   = "Done"
+	akoCleanUpTimeoutStatus    = "Timeout"
 )
 
 func CleanupFinished(ctx context.Context, remoteClient client.Client, log logr.Logger) (bool, error) {
@@ -37,5 +38,13 @@ func CleanupFinished(ctx context.Context, remoteClient client.Client, log logr.L
 		return false, err
 	}
 
-	return ss.Annotations[akoCleanUpAnnotationKey] == akoCleanUpFinishedStatus, nil
+	if ss.Annotations[akoCleanUpAnnotationKey] == akoCleanUpFinishedStatus {
+		log.Info("Avi resource cleanup finished")
+		return true, nil
+	} else if ss.Annotations[akoCleanUpAnnotationKey] == akoCleanUpTimeoutStatus {
+		log.Info("Avi resource cleanup timed out")
+		return true, nil
+	}
+	log.Info("Avi resource cleanup in progress")
+	return false, nil
 }

--- a/pkg/ako/ako_test.go
+++ b/pkg/ako/ako_test.go
@@ -92,4 +92,15 @@ var _ = Describe("AKO", func() {
 			Expect(finished).To(BeTrue())
 		})
 	})
+	When("Clean up annotation is timeout", func() {
+		BeforeEach(func() {
+			ss.Annotations = map[string]string{
+				akoCleanUpAnnotationKey: akoCleanUpTimeoutStatus,
+			}
+		})
+		It("should claim finished", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(finished).To(BeTrue())
+		})
+	})
 })


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

Currently, when Avi resource cleanup timeout, we will still wait for cleanup finish and stuck there forever, this PR handles cleanup timeout condition.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
- Unit test cases passed
- Integration test cases passed.
- e2e test in progress.

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.