### PR TITLE
Temporarily stop adding annotation to HA svc

### DIFF
--- a/pkg/haprovider/haprovider.go
+++ b/pkg/haprovider/haprovider.go
@@ -138,15 +138,16 @@ func (r *HAProvider) annotateService(ctx context.Context, cluster *clusterv1.Clu
 		return serviceAnnotation, nil
 	}
 
-	aviInfraSetting, err := r.getAviInfraSettingFromCluster(ctx, cluster)
-	if err != nil {
-		return serviceAnnotation, err
-	}
+	// TODO(iXinqi): Temporarily commenting adding annotation to HA svc, will uncomment it after the feature is fully tested.
+	//aviInfraSetting, err := r.getAviInfraSettingFromCluster(ctx, cluster)
+	//if err != nil {
+	//	return serviceAnnotation, err
+	//}
 
-	if aviInfraSetting != nil {
-		// add AVIInfraSetting annotation when creating HA svc
-		serviceAnnotation[akoov1alpha1.HAAVIInfraSettingAnnotationsKey] = aviInfraSetting.Name
-	}
+	//if aviInfraSetting != nil {
+	//	// add AVIInfraSetting annotation when creating HA svc
+	//	serviceAnnotation[akoov1alpha1.HAAVIInfraSettingAnnotationsKey] = aviInfraSetting.Name
+	//}
 	return serviceAnnotation, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently there is race issue in creating cluster with HA enabled which causes the cluster disconnected with kubectl. Also, we lack the mechanism to prevent user from editing controlPlane network which may also cause the cluster disconnected. Therefore, we stop adding annotation to HA svc to avoid disconnection of cluster and will add the annotation back when the issues are fixed and fully tested.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.