### PR TITLE
Init AVI client in the configmap controller to avoid nil pointer error.

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -30,6 +30,7 @@ const (
 	AkoStatefulSetName            = "ako"
 	AkoConfigMapName              = "avi-k8s-config"
 	AkoConfigMapCloudNameKey      = "cloudName"
+	AkoConfigMapControllerIPKey   = "controllerIP"
 	AkoConfigMapVipNetworkListKey = "vipNetworkList"
 
 	AVI_VERSION                                                  = "20.1.3"
@@ -37,6 +38,8 @@ const (
 	AviClusterSelectedLabel                                      = "networking.tkg.tanzu.vmware.com/avi-skip-default-adc"
 	AviClusterSecretType                                         = "avi.cluster.x-k8s.io/secret"
 	AviNamespace                                                 = "avi-system"
+	AviCredentialName                                            = "avi-controller-credentials"
+	AviCAName                                                    = "avi-controller-ca"
 	AviCertificateKey                                            = "certificateAuthorityData"
 	AviResourceCleanupReason                                     = "AviResourceCleanup"
 	AviResourceCleanupSucceededCondition clusterv1.ConditionType = "AviResourceCleanupSucceeded"

--- a/controllers/configmap/configmap_intg_test.go
+++ b/controllers/configmap/configmap_intg_test.go
@@ -38,6 +38,7 @@ func intgTestEnsureUsableNetworkAddedInBootstrapCluster() {
 			Namespace: "tkg-system",
 		},
 		Data: map[string]string{
+			"controllerIP":   "10.168.176.11",
 			"cloudName":      "Default Cloud 2",
 			"vipNetworkList": "[{\"networkName\":\"VM Network 2\",\"cidr\":\"10.168.176.0/20\"}]",
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

It fixes the CrashLoopBackOff with the nil pointer error message.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Manual validation in progress for RC4


**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Init AVI client in the configmap controller to avoid nil pointer error.
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.