### PR TITLE
Manage AKO "deleteConfig" flag based on cluster label

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -36,6 +36,7 @@ const (
 	AVI_VERSION                                                  = "20.1.3"
 	AviClusterLabel                                              = "networking.tkg.tanzu.vmware.com/avi"
 	AviClusterSelectedLabel                                      = "networking.tkg.tanzu.vmware.com/avi-skip-default-adc"
+	AviClusterDeleteConfigLabel                                  = "networking.tkg.tanzu.vmware.com/avi-config-delete"
 	AviClusterSecretType                                         = "avi.cluster.x-k8s.io/secret"
 	AviNamespace                                                 = "avi-system"
 	AviCredentialName                                            = "avi-controller-credentials"

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
@@ -114,6 +114,16 @@ func AkoAddonSecretDataYaml(cluster *clusterv1.Cluster, obj *akoov1alpha1.AKODep
 	if err != nil {
 		return "", err
 	}
+
+	//Avoid setting DeleteConfig for management cluster
+	if cluster.Namespace != akoov1alpha1.TKGSystemNamespace {
+		if deleteConfig, exists := cluster.Labels[akoov1alpha1.AviClusterDeleteConfigLabel]; exists {
+			if deleteConfig == "true" {
+				secret.LoadBalancerAndIngressService.Config.AKOSettings.DeleteConfig = "true"
+			}
+		}
+	}
+
 	secret.LoadBalancerAndIngressService.Config.Avicredentials.Username = string(aviUsersecret.Data["username"][:])
 	secret.LoadBalancerAndIngressService.Config.Avicredentials.Password = string(aviUsersecret.Data["password"][:])
 	secret.LoadBalancerAndIngressService.Config.Avicredentials.CertificateAuthorityData = string(aviUsersecret.Data[akoov1alpha1.AviCertificateKey][:])

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
@@ -101,7 +101,8 @@ func unitTestAKODeploymentYaml() {
 		BeforeEach(func() {
 			capicluster = &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-cluster",
+					Name:   "test-cluster",
+					Labels: map[string]string{},
 				},
 			}
 		})
@@ -192,6 +193,55 @@ func unitTestAKODeploymentYaml() {
 				secretData, err := values.YttYaml()
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(secretData).Should(ContainSubstring("delete_config: \"true\""))
+			})
+
+			When("cluster has avi_delete_config label", func() {
+				BeforeEach(func() {
+					capicluster.Labels[akoov1alpha1.AviClusterDeleteConfigLabel] = "true"
+				})
+
+				It("deleteConfig True in add_on_secret when cluster has avi_delete_config label set to true", func() {
+					secretData, err := cluster.AkoAddonSecretDataYaml(capicluster, akoDeploymentConfig, aviUserSecret)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(secretData).Should(ContainSubstring("delete_config: \"true\""))
+				})
+
+				It("deleteConfig False in add_on_secret when cluster has avi_delete_config label set to false", func() {
+					capicluster.Labels[akoov1alpha1.AviClusterDeleteConfigLabel] = "false"
+					secretData, err := cluster.AkoAddonSecretDataYaml(capicluster, akoDeploymentConfig, aviUserSecret)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(secretData).Should(ContainSubstring("delete_config: \"false\""))
+				})
+
+				It("deleteConfig True in add_on_secret when cluster has avi_delete_config label set to true", func() {
+					secretData, err := cluster.AkoAddonSecretDataYaml(capicluster, akoDeploymentConfig, aviUserSecret)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(secretData).Should(ContainSubstring("delete_config: \"true\""))
+				})
+
+				It("deleteConfig False in add_on_secret when cluster has avi_delete_config label set to false", func() {
+					delete(capicluster.Labels, akoov1alpha1.AviClusterDeleteConfigLabel)
+					secretData, err := cluster.AkoAddonSecretDataYaml(capicluster, akoDeploymentConfig, aviUserSecret)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(secretData).Should(ContainSubstring("delete_config: \"false\""))
+				})
+
+				When("management cluster has avi_delete_config label", func() {
+					BeforeEach(func() {
+						capicluster.Namespace = akoov1alpha1.TKGSystemNamespace
+					})
+
+					It("deleteConfig always False in add_on_secret", func() {
+						secretData, err := cluster.AkoAddonSecretDataYaml(capicluster, akoDeploymentConfig, aviUserSecret)
+						Expect(err).ShouldNot(HaveOccurred())
+						Expect(secretData).Should(ContainSubstring("delete_config: \"false\""))
+
+						delete(capicluster.Labels, akoov1alpha1.AviClusterDeleteConfigLabel)
+						secretData, err = cluster.AkoAddonSecretDataYaml(capicluster, akoDeploymentConfig, aviUserSecret)
+						Expect(err).ShouldNot(HaveOccurred())
+						Expect(secretData).Should(ContainSubstring("delete_config: \"false\""))
+					})
+				})
 			})
 		})
 	})


### PR DESCRIPTION
During cluster upgrade from TKG-M to U-TKG, AVI resources can be deleted/re-added
by managing "deleteConfig" AKO flag

Signed-off-by: Sharath Bhat <sharathb@vmware.com>

**What this PR does / why we need it**:
During workload cluster upgrade from TKG-M to U-TKG, AVI resources needs to be deleted for the cluster by setting "disableConfig" flag in AKO config. To achieve this, user will set avi-delete-config label on the cluster. AKOO will set "disableConfig" if the workload cluster label this label

**Which issue(s) this PR fixes**:
TKG-8786

Fixes #

**Describe testing done for PR**:
Tested on the jenkins setup
Added UT case

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.