### PR TITLE
Delete the avi-skip-default-adc label when the cluster is no longer selected by a custom ADC.

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -21,6 +21,7 @@ const (
 	TKGDataValueFormatString    = "#@data/values\n#@overlay/match-child-defaults missing_ok=True\n---\n"
 
 	ManagementClusterAkoDeploymentConfig = "install-ako-for-management-cluster"
+	WorkloadClusterAkoDeploymentConfig   = "install-ako-for-all"
 
 	AkoUserRoleName               = "ako-essential-role"
 	ClusterFinalizer              = "ako-operator.networking.tkg.tanzu.vmware.com"


### PR DESCRIPTION
**What this PR does / why we need it**:

We should remove the label `networking.tkg.tanzu.vmware.com/avi-skip-default-adc` when a cluster is switched back to use default ADC from a custom one. Otherwise, there would be no ADC responsible for this cluster ever again.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # 



**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

Added an integration test
`when there is default ADC install-ako-for-all` and the cluster `no longer selected by a customized ADC`, assert the cluster controller `should drop the skip-default-adc label (AviClusterSelectedLabel)`

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Delete the avi-skip-default-adc label when the cluster is no longer selected by a custom ADC
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.