### PR TITLE
[cherry-pick] temp disable usable network to fix throwing errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PUBLISH?=publish
 BUILD_VERSION ?= $(shell git describe --always --match "v*" | sed 's/v//')
 
 # TKG Version
-TKG_VERSION ?= v1.5.0+vmware.3
+TKG_VERSION ?= v1.5.0+vmware.4
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller.go
@@ -5,6 +5,7 @@ package akodeploymentconfig
 
 import (
 	"context"
+
 	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/netprovider"
 
 	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/controllers/akodeploymentconfig/cluster"

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
@@ -71,7 +71,6 @@ func (r *AKODeploymentConfigReconciler) reconcileAVI(
 
 	return phases.ReconcilePhases(ctx, log, obj, []phases.ReconcilePhase{
 		r.reconcileNetworkSubnets,
-		r.reconcileCloudUsableNetwork,
 		r.reconcileAviInfraSetting,
 		func(ctx context.Context, log logr.Logger, obj *akoov1alpha1.AKODeploymentConfig) (ctrl.Result, error) {
 			return phases.ReconcileClustersPhases(ctx, r.Client, log, obj,
@@ -166,26 +165,26 @@ func (r *AKODeploymentConfigReconciler) reconcileNetworkSubnets(
 	return res, nil
 }
 
-func (r *AKODeploymentConfigReconciler) reconcileCloudUsableNetwork(
-	ctx context.Context,
-	log logr.Logger,
-	obj *akoov1alpha1.AKODeploymentConfig,
-) (ctrl.Result, error) {
-	log = log.WithValues("cloud", obj.Spec.CloudName)
-	log.Info("Start reconciling AVI cloud usable network")
+// func (r *AKODeploymentConfigReconciler) reconcileCloudUsableNetwork(
+// 	ctx context.Context,
+// 	log logr.Logger,
+// 	obj *akoov1alpha1.AKODeploymentConfig,
+// ) (ctrl.Result, error) {
+// 	log = log.WithValues("cloud", obj.Spec.CloudName)
+// 	log.Info("Start reconciling AVI cloud usable network")
 
-	added, err := r.AddUsableNetwork(r.aviClient, obj.Spec.CloudName, obj.Spec.DataNetwork.Name)
-	if err != nil {
-		log.Error(err, "Failed to add usable network", obj.Spec.DataNetwork.Name)
-		return ctrl.Result{}, err
-	}
-	if added {
-		log.Info("Added Usable Network", obj.Spec.DataNetwork.Name)
-	} else {
-		log.Info("Network is already one of the cloud's usable network", obj.Spec.DataNetwork.Name)
-	}
-	return ctrl.Result{}, nil
-}
+// 	added, err := r.AddUsableNetwork(r.aviClient, obj.Spec.CloudName, obj.Spec.DataNetwork.Name)
+// 	if err != nil {
+// 		log.Error(err, "Failed to add usable network", obj.Spec.DataNetwork.Name)
+// 		return ctrl.Result{}, err
+// 	}
+// 	if added {
+// 		log.Info("Added Usable Network", obj.Spec.DataNetwork.Name)
+// 	} else {
+// 		log.Info("Network is already one of the cloud's usable network", obj.Spec.DataNetwork.Name)
+// 	}
+// 	return ctrl.Result{}, nil
+// }
 
 func (r *AKODeploymentConfigReconciler) reconcileAviInfraSetting(
 	ctx context.Context,


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

Temp fix adding usable network keeps throwing error

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Disable adding usable network
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.