### PR TITLE
Add corner case when we get avi controller version

### DIFF
--- a/pkg/ako-operator/config_envvar.go
+++ b/pkg/ako-operator/config_envvar.go
@@ -46,7 +46,7 @@ func GetControlPlaneEndpointPort() int32 {
 
 func GetAVIControllerVersion() string {
 	version, set := os.LookupEnv(AVIControllerVersion)
-	if set {
+	if set && version != ""{
 		return version
 	}
 	return akoov1alpha1.AVI_VERSION

--- a/pkg/ako-operator/config_envvar_test.go
+++ b/pkg/ako-operator/config_envvar_test.go
@@ -1,0 +1,81 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ako_operator
+
+import (
+	akoov1alpha1 "github.com/vmware-samples/load-balancer-operator-for-kubernetes/api/v1alpha1"
+	"os"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AKO Operator", func() {
+	Context("If ako operator is deployed in bootstrap cluster", func() {
+		When("ako operator is deployed in bootstrap cluster", func() {
+			BeforeEach(func() {
+				os.Setenv(DeployInBootstrapCluster, "True")
+			})
+			It("should return True", func() {
+				Expect(IsBootStrapCluster()).Should(Equal(true))
+			})
+		})
+	})
+
+	Context("If ako operator is going to provide control plane HA", func() {
+		When("ako operator provides control plane HA", func() {
+			BeforeEach(func() {
+				os.Setenv(IsControlPlaneHAProvider, "True")
+			})
+			It("should return True", func() {
+				Expect(IsHAProvider()).Should(Equal(true))
+			})
+		})
+	})
+
+	Context("Get control plane endpoint port", func() {
+		When("There is a valid control plane endpoint port", func() {
+			BeforeEach(func() {
+				os.Setenv(ControlPlaneEndpointPort, "6001")
+			})
+			It("should return port in env", func() {
+				Expect(GetControlPlaneEndpointPort()).Should(Equal(int32(6001)))
+			})
+		})
+
+		When("There is an invalid control plane endpoint port", func() {
+			BeforeEach(func() {
+				os.Setenv(ControlPlaneEndpointPort, "-1")
+			})
+			It("should return port 6443", func() {
+				Expect(GetControlPlaneEndpointPort()).Should(Equal(int32(6443)))
+			})
+		})
+	})
+
+	Context("Get AVI Controller Version", func() {
+		When("avi controller version is successfully set", func() {
+			BeforeEach(func() {
+				os.Setenv(AVIControllerVersion, "20.1.1")
+			})
+			It("should return version 20.1.1", func() {
+				Expect(GetAVIControllerVersion()).Should(Equal("20.1.1"))
+			})
+		})
+
+		When("avi controller version is set but the value is empty", func() {
+			BeforeEach(func() {
+				os.Setenv(AVIControllerVersion, "")
+			})
+			It("should return default avi controller version", func() {
+				Expect(GetAVIControllerVersion()).Should(Equal(akoov1alpha1.AVI_VERSION))
+			})
+		})
+
+		When("avi controller version is not set", func() {
+			It("should return default avi controller version", func() {
+				Expect(GetAVIControllerVersion()).Should(Equal(akoov1alpha1.AVI_VERSION))
+			})
+		})
+	})
+})

--- a/pkg/ako-operator/suite_test.go
+++ b/pkg/ako-operator/suite_test.go
@@ -1,0 +1,16 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ako_operator
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AKO Operator Suite")
+}


### PR DESCRIPTION
- Add corner case when we get avi controller version
- Add unit test for config_envvar.go file

Signed-off-by: Chen Lin <linch@vmware.com>

**What this PR does / why we need it**:
- We need to consider the corner case that we set avi controller version parameter but the value is empty. In this case, we want to return the default avi controller version.
- We need unit test for config_envvar.go file

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Add unit test
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.