### PR TITLE
Fix potential ip mix up when using avi to provider control plane VIP 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PUBLISH?=publish
 BUILD_VERSION ?= $(shell git describe --always --match "v*" | sed 's/v//')
 
 # TKG Version
-TKG_VERSION ?= v1.6.0+vmware.3
+TKG_VERSION ?= v1.6.0+vmware.5
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	akoov1alpha1 "github.com/vmware-samples/load-balancer-operator-for-kubernetes/api/v1alpha1"
 	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/ako"
+	akoo "github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/ako-operator"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +31,20 @@ func (r *ClusterReconciler) ReconcileAddonSecret(
 		log.Info("Failed to get cluster avi user secret, requeue")
 		return res, err
 	}
+
+	// when avi is ha provider and deploy ako in management cluster, need to wait for
+	// control plane load balancer type of service creating
+	if akoo.IsHAProvider() && cluster.Namespace == akoov1alpha1.TKGSystemNamespace {
+		svc := &corev1.Service{}
+		if err = r.Get(ctx, client.ObjectKey{
+			Name:      cluster.Namespace + "-" + cluster.Name + "-" + akoov1alpha1.HAServiceName,
+			Namespace: akoov1alpha1.TKGSystemNamespace,
+		}, svc); err != nil {
+			log.Info("Failed to get cluster control plane load balancer type of service, requeue")
+			return res, err
+		}
+	}
+
 	newAddonSecret, err := r.createAKOAddonSecret(cluster, obj, aviSecret)
 	if err != nil {
 		log.Info("Failed to convert AKO Deployment Config to add-on secret, requeue the request")


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

When using AVI to provide control plane VIP in TKG, during management cluster creating, if we deploy AKO before we create control plane load balancer type of service, AKO will delete all existing virtual services, then create it again when the lb type of service re-creating by load balancer operator.

This brings a potential IP mix-up issue, so we have to ensure the control plane load balancer type of service creating before deploying ako.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

- TODO

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.

/kind bug