### PR TITLE
Pass cluster role information to ako package

### DIFF
--- a/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
@@ -130,8 +130,12 @@ func AkoAddonSecretDataYaml(cluster *clusterv1.Cluster, obj *akoov1alpha1.AKODep
 		return "", err
 	}
 
+	//Pass cluster role information to ako
 	//Avoid setting DeleteConfig for management cluster
-	if cluster.Namespace != akoov1alpha1.TKGSystemNamespace {
+	if cluster.Namespace == akoov1alpha1.TKGSystemNamespace {
+		secret.LoadBalancerAndIngressService.Config.TkgClusterRole = "management"
+	} else {
+		secret.LoadBalancerAndIngressService.Config.TkgClusterRole = "workload"
 		if deleteConfig, exists := cluster.Labels[akoov1alpha1.AviClusterDeleteConfigLabel]; exists {
 			if deleteConfig == "true" {
 				secret.LoadBalancerAndIngressService.Config.AKOSettings.DeleteConfig = "true"

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
@@ -22,6 +22,7 @@ loadBalancerAndIngressService:
     name: ako--test-cluster
     namespace: avi-system
     config:
+        tkg_cluster_role: workload
         is_cluster_service: ""
         replica_count: 1
         ako_settings:

--- a/pkg/ako/values.go
+++ b/pkg/ako/values.go
@@ -100,6 +100,7 @@ type LoadBalancerAndIngressService struct {
 // Config consists of different configurations for Values that includes settings of
 // AKO, networking, L4, L7, Rbac etc
 type Config struct {
+	TkgClusterRole        string              `yaml:"tkg_cluster_role"`
 	IsClusterService      string              `yaml:"is_cluster_service"`
 	ReplicaCount          int                 `yaml:"replica_count"`
 	AKOSettings           *AKOSettings        `yaml:"ako_settings"`
@@ -271,7 +272,9 @@ func NewNetworkSettings(obj *akoov1alpha1.AKODeploymentConfig) (*NetworkSettings
 	if obj.Spec.ExtraConfigs.NetworksConfig.EnableRHI != nil {
 		settings.EnableRHI = strconv.FormatBool(*obj.Spec.ExtraConfigs.NetworksConfig.EnableRHI)
 	}
-	settings.NsxtT1LR = obj.Spec.ExtraConfigs.NetworksConfig.NsxtT1LR
+	if obj.Spec.ExtraConfigs.NetworksConfig.NsxtT1LR != "" {
+		settings.NsxtT1LR = obj.Spec.ExtraConfigs.NetworksConfig.NsxtT1LR
+	}
 	settings.BGPPeerLabels = obj.Spec.ExtraConfigs.NetworksConfig.BGPPeerLabels
 	if len(settings.BGPPeerLabels) != 0 {
 		jsonBytes, err := json.Marshal(settings.BGPPeerLabels)


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

AKO Package needs cluster role information to decide it needs to deploy `aviinfrasetting` crd in or not in tkg. If it's in the management cluster, ako package doesn't need to deploy `aviinfrasetting` crd, otherwise, it needs. This PR enables load balancer operator can pass that information to ako package.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
expose cluster role information to ako
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.