### PR TITLE
Improve log format for ako-operator

### DIFF
--- a/controllers/cluster/cluster_controller.go
+++ b/controllers/cluster/cluster_controller.go
@@ -109,7 +109,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 		if selector, err := metav1.LabelSelectorAsSelector(&akoDeploymentConfig.Spec.ClusterSelector); err != nil {
 			log.Error(err, "Failed to convert label sector to selector when matching ", cluster.Name, " with ", akoDeploymentConfig.Name)
 		} else if selector.Matches(labels.Set(clusterLabels)) {
-			log.Info("Cluster ", cluster.Name, " is selected by Akodeploymentconfig ", akoDeploymentConfig.Namespace+"/"+akoDeploymentConfig.Name)
+			log.Info("Cluster ", cluster.Name, " is selected by", "Akodeploymentconfig", (akoDeploymentConfig.Namespace + "/" + akoDeploymentConfig.Name))
 			matchedAkoDeploymentConfigs = append(matchedAkoDeploymentConfigs, akoDeploymentConfig)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes v0.0.0-20211102041403-f2ed902e4706 // indirect
+	go.uber.org/zap v1.19.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2


### PR DESCRIPTION
Sample output:
```2022-02-24T22:47:07.902Z	INFO	controllers.AKODeploymentConfig	AVI Client initialized successfully	{"AKODeploymentConfig": "/install-ako-for-all"}
2022-02-24T22:47:07.497Z	INFO	controllers.Cluster	Cluster doesn't have AVI enabled, skip Cluster reconciling	{"Cluster": "default/tkg-vc-antrea", "Cluster": "default/tkg-vc-antrea"}
2022-02-24T22:47:07.902Z	INFO	controllers.AKODeploymentConfig	AVI Client initialized successfully	{"AKODeploymentConfig": "/install-ako-for-all"}
2022-02-24T22:47:07.902Z	INFO	controllers.AKODeploymentConfig	Ako User Reconciler initialized	{"AKODeploymentConfig": "/install-ako-for-all"}
2022-02-24T22:47:07.902Z	INFO	controllers.AKODeploymentConfig	Start reconciling AVI Network Subnets sbhat	{"AKODeploymentConfig": "/install-ako-for-all"}
```



**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #57

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.