### PR TITLE
Update avi certificate in addon-secret on day1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PUBLISH?=publish
 BUILD_VERSION ?= $(shell git describe --always --match "v*" | sed 's/v//')
 
 # TKG Version
-TKG_VERSION ?= v1.6.0+vmware.5
+TKG_VERSION ?= v1.6.0+vmware.7
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller.go
@@ -5,12 +5,11 @@ package akodeploymentconfig
 
 import (
 	"context"
-
-	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/netprovider"
-
 	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/controllers/akodeploymentconfig/cluster"
 	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/controllers/akodeploymentconfig/phases"
 	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/controllers/akodeploymentconfig/user"
+	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/netprovider"
+	corev1 "k8s.io/api/core/v1"
 
 	controllerruntime "github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/controller-runtime"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -39,6 +38,10 @@ func (r *AKODeploymentConfigReconciler) SetupWithManager(mgr ctrl.Manager) error
 		Watches(
 			&source.Kind{Type: &clusterv1.Cluster{}},
 			handler.EnqueueRequestsFromMapFunc(handlers.AkoDeploymentConfigForCluster(r.Client, r.Log)),
+		).
+		Watches(
+			&source.Kind{Type: &corev1.Secret{}},
+			handler.EnqueueRequestsFromMapFunc(handlers.AkoDeploymentConfigForSecret(r.Client, r.Log)),
 		).
 		Complete(r)
 }

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_intg_test.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_intg_test.go
@@ -43,8 +43,8 @@ func intgTestAkoDeploymentConfigController() {
 		staticControllerCA               *corev1.Secret
 		testLabels                       map[string]string
 		err                              error
-		aviInfraSettingName	             string
-		serviceName string
+		aviInfraSettingName              string
+		serviceName                      string
 
 		networkUpdate        *models.Network
 		userUpdateCalled     bool
@@ -121,7 +121,7 @@ func intgTestAkoDeploymentConfigController() {
 		},
 		Type: "Opaque",
 		Data: map[string][]byte{
-			"certificateAuthorityData": []byte("-----BEGIN CERTIFICATE-----MIICxzCCAa+gAwIBAgIUWxv6EsFnaXvTF4Lbwk9BucKJhgowDQYJKoZIhvcNAQELBQAwEzERMA8GA1UEAwwIZTJlLXRlc3QwHhcNMjEwMjE2MjAzNTU1WhcNMjIwMjE2MjAzNTU1WjATMREwDwYDVQQDDAhlMmUtdGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALxAXjEjZvandPgciqEerY7ptVqzdPIP0MHFA/ky0e7NVszgjHj5OcWAPnPD11p0zkR1tXknJRSJOeJnbJLNWTF5ApsOZWP9tUHt+TmvA3hVKZQiFb79VlF/VaVdJPb9vMYFjJyAlZj6rH8HABQ/Y9ysUozVaFaIMcx4sdIWxG0eGfmFT1Yrh1yZGnf0pESfcx4IzFZmQQIRvqKHZToaQEGX6T6oisM37qdrbWmPdQF2S3aFyoW/lDEqoVNJ5pzDdbTOf4CaqaPsNXbhQFF6LX2Q9kAnltwLxcdVN+KvN3Hqgif0jokEqmojhSK/bCatesMwImTmaYKG2+lK9dHbUCMCAwEAAaMTMBEwDwYDVR0RBAgwBocECqFgVTANBgkqhkiG9w0BAQsFAAOCAQEAcvgfGtVc9416oPbI7e11Kufy3DptOsMjFz7S5W1ifhDfRseEpv1oVgg4+qFVVBMyQgfH1DZ985TbwsozGCib4cU00/Tk7aoFy5TNC2xP8XJgJb5TDC4EaISgR2GPDsIW+BqkYX5jCDEMqnlGJBjG6V/z5OhqWUFZmb5Ly5qjxqt6JBP+E/z5fnZquFFNjhGIgnlpQDF6plKzYnJy5d3Yc5EurmYOmoQ/7gX/Sv6RTbha4UnQh4LsURT/sBurMW3fFdZsD5cH0t8SgxOeqsDa8YSr2T74BRm5rqKRGgX5Rz0TBJ9m6ViO3VwBceJFd2O/Gd6ElhJ81SM0lOp/jf5Hlg==-----END CERTIFICATE-----"),
+			"certificateAuthorityData": []byte(""),
 		},
 	}
 
@@ -345,6 +345,7 @@ func intgTestAkoDeploymentConfigController() {
 				Namespace: cluster.Namespace,
 			}, &clusterv1.Cluster{}, false)
 			deleteObjects(akoDeploymentConfig)
+			deleteObjects(controllerCredentials, controllerCA)
 			ensureRuntimeObjectMatchExpectation(client.ObjectKey{
 				Name: akoDeploymentConfig.Name,
 			}, &akoov1alpha1.AKODeploymentConfig{}, false)
@@ -353,10 +354,10 @@ func intgTestAkoDeploymentConfigController() {
 		})
 		It("shouldn't wait AIS if controlplane and dataplane has the same CIDR", func() {
 			akoDeploymentConfig.Spec.ControlPlaneNetwork.CIDR = akoDeploymentConfig.Spec.DataNetwork.CIDR
-			createObjects(akoDeploymentConfig, cluster)
+			createObjects(akoDeploymentConfig, cluster, controllerCredentials, controllerCA)
 			aviInfraSettingName = akoDeploymentConfig.Name + "-ais"
 			ensureRuntimeObjectMatchExpectation(client.ObjectKey{
-				Name:      aviInfraSettingName,
+				Name: aviInfraSettingName,
 			}, &akov1alpha1.AviInfraSetting{}, true)
 
 			service := &corev1.Service{}
@@ -369,10 +370,10 @@ func intgTestAkoDeploymentConfigController() {
 
 		})
 		It("should wait AIS before adding annotation to service", func() {
-			createObjects(akoDeploymentConfig, cluster)
+			createObjects(akoDeploymentConfig, cluster, controllerCredentials, controllerCA)
 			aviInfraSettingName = akoDeploymentConfig.Name + "-ais"
 			ensureRuntimeObjectMatchExpectation(client.ObjectKey{
-				Name:      aviInfraSettingName,
+				Name: aviInfraSettingName,
 			}, &akov1alpha1.AviInfraSetting{}, true)
 
 			service := &corev1.Service{}

--- a/controllers/akodeploymentconfig/user/user_controller.go
+++ b/controllers/akodeploymentconfig/user/user_controller.go
@@ -222,6 +222,13 @@ func (r *AkoUserReconciler) reconcileAviUserNormal(
 				log.Error(err, "Failed to get cluster avi user secret, requeue")
 				return res, err
 			}
+		} else {
+			// controller certificate can be updated by the user
+			mcSecret.Data[akoov1alpha1.AviCertificateKey] = []byte(aviCA)
+			if err := r.Client.Update(ctx, mcSecret); err != nil {
+				log.Error(err, "Failed to update avi-credentials secret, requeue")
+				return res, err
+			}
 		}
 
 		// Use the value from the management cluster

--- a/pkg/aviclient/client.go
+++ b/pkg/aviclient/client.go
@@ -235,3 +235,7 @@ func (r *realAviClient) VirtualServiceGetByName(name string, options ...session.
 func (r *realAviClient) PoolGetByName(name string, options ...session.ApiOptionsParams) (*models.Pool, error) {
 	return r.Pool.GetByName(name)
 }
+
+func (r *realAviClient) AviCertificateConfig() (string, error) {
+	return r.config.CA, nil
+}

--- a/pkg/aviclient/fake_avi_client.go
+++ b/pkg/aviclient/fake_avi_client.go
@@ -86,6 +86,10 @@ func (r *FakeAviClient) PoolGetByName(name string, options ...session.ApiOptions
 	return r.Pool.GetByName(name)
 }
 
+func (r *FakeAviClient) AviCertificateConfig() (string, error) {
+	return "", nil
+}
+
 // Network Client
 type NetworkClient struct {
 	getByNameFn GetByNameFunc

--- a/pkg/aviclient/interface.go
+++ b/pkg/aviclient/interface.go
@@ -29,4 +29,6 @@ type Client interface {
 	VirtualServiceGetByName(name string, options ...session.ApiOptionsParams) (*models.VirtualService, error)
 
 	PoolGetByName(name string, options ...session.ApiOptionsParams) (*models.Pool, error)
+
+	AviCertificateConfig() (string, error)
 }

--- a/pkg/controller-runtime/handlers/cluster_for_akodeploymentconfig_handler.go
+++ b/pkg/controller-runtime/handlers/cluster_for_akodeploymentconfig_handler.go
@@ -6,7 +6,6 @@ package handlers
 import (
 	"context"
 	"fmt"
-
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	akoov1alpha1 "github.com/vmware-samples/load-balancer-operator-for-kubernetes/api/v1alpha1"

--- a/pkg/controller-runtime/handlers/secret_for_akodeploymentconfig_handler.go
+++ b/pkg/controller-runtime/handlers/secret_for_akodeploymentconfig_handler.go
@@ -1,0 +1,59 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	akoov1alpha1 "github.com/vmware-samples/load-balancer-operator-for-kubernetes/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func AkoDeploymentConfigForSecret(c client.Client, log logr.Logger) handler.MapFunc {
+	return func(o client.Object) []reconcile.Request {
+		ctx := context.Background()
+		secret, ok := o.(*corev1.Secret)
+		if !ok {
+			log.Error(errors.New("invalid type"),
+				"Expected to receive Cluster resource",
+				"actualType", fmt.Sprintf("%T", o))
+			return nil
+		}
+		logger := log.WithValues("Secret", secret.Namespace+"/"+secret.Name)
+
+		if secret.Name != akoov1alpha1.AviCredentialName && secret.Name != akoov1alpha1.AviCAName {
+			return []reconcile.Request{}
+		}
+
+		var akoDeploymentConfigs akoov1alpha1.AKODeploymentConfigList
+		if err := c.List(ctx, &akoDeploymentConfigs, []client.ListOption{}...); err != nil {
+			logger.Error(err, "Couldn't read ADCs")
+			return []reconcile.Request{}
+		}
+
+		var requests []ctrl.Request
+		for _, akoDeploymentConfig := range akoDeploymentConfigs.Items {
+			if akoDeploymentConfig.Spec.CertificateAuthorityRef.Name == secret.Name &&
+				akoDeploymentConfig.Spec.CertificateAuthorityRef.Namespace == secret.Namespace {
+				requests = append(requests, ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: akoDeploymentConfig.Namespace,
+						Name:      akoDeploymentConfig.Name,
+					},
+				})
+			}
+		}
+
+		logger.Info("Generating requests", "requests", requests)
+		// Return reconcile requests for the AKODeploymentConfig resources.
+		return requests
+	}
+}


### PR DESCRIPTION
ako-opertor was not updating addon-secret with updated certificate if certificate
is updated later on day 1

Signed-off-by: Sharath Bhat <sharathb@vmware.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.