### PR TITLE
Update the manager RBAC to be consistent with TCE.

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ako.vmware.com
+  resources:
+  - aviinfrasettings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - cluster.x-k8s.io
   resources:
   - clusters
@@ -43,6 +55,20 @@ rules:
   - get
   - list
   - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - endpoints/status
+  - services
+  - services/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
   - update
   - watch
 - apiGroups:

--- a/config/ytt/static.yaml
+++ b/config/ytt/static.yaml
@@ -577,6 +577,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ako.vmware.com
+  resources:
+  - aviinfrasettings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - cluster.x-k8s.io
   resources:
   - clusters
@@ -600,6 +612,20 @@ rules:
   - get
   - list
   - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - endpoints/status
+  - services
+  - services/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
   - update
   - watch
 - apiGroups:

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller.go
@@ -59,9 +59,11 @@ func (r *AKODeploymentConfigReconciler) SetAviClient(client aviclient.Client) {
 
 // AKODeploymentConfigReconciler reconciles a AKODeploymentConfig object
 
+// +kubebuilder:rbac:groups=core,resources=services;services/status;endpoints;endpoints/status,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=networking.tkg.tanzu.vmware.com,resources=akodeploymentconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.tkg.tanzu.vmware.com,resources=akodeploymentconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;create;list;watch;update;delete
+// +kubebuilder:rbac:groups=ako.vmware.com,resources=aviinfrasettings,verbs=get;list;watch;create;update;patch;delete
 
 func (r *AKODeploymentConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	log := r.Log.WithValues("AKODeploymentConfig", req.NamespacedName)


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, deploying the ako-operator for a local kind cluster is failing because of lack of RBAC permission using `make deploy`. This is caused by the discrepency between the upstream ako-operator controller RBAC markers and the current TCE ako-operator RBAC. This PR adds the required RBAC marker and makes it the same with AKOO TCE RBAC defined [here](https://github.com/vmware-tanzu/community-edition/blob/9b34011f061c73083e23f154cfcc04ad082bce26/addons/packages/ako-operator/1.6.0/bundle/config/upstream/akooperator/static.yaml#L433)

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Upstream ako-operator integration test.


**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.