### PR TITLE
Fix panic issue when trying to add usable network caused by zap logging.

### DIFF
--- a/controllers/configmap/configmap_controller.go
+++ b/controllers/configmap/configmap_controller.go
@@ -121,13 +121,13 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	for _, vipNetwork := range vipNetworkList {
 		added, err := r.AddUsableNetwork(r.aviClient, cloudName, vipNetwork.NetworkName)
 		if err != nil {
-			log.Error(err, "Failed to add usable network", vipNetwork.NetworkName)
+			log.Error(err, "Failed to add usable network", "network", vipNetwork.NetworkName)
 			return ctrl.Result{}, err
 		}
 		if added {
-			log.Info("Added Usable Network", vipNetwork.NetworkName)
+			log.Info("Added Usable Network", "network", vipNetwork.NetworkName)
 		} else {
-			log.Info("Network is already one of the cloud's usable network", vipNetwork.NetworkName)
+			log.Info("Network is already one of the cloud's usable network", "network", vipNetwork.NetworkName)
 		}
 	}
 	return ctrl.Result{}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix ako-operator manager crashing due to the panic brought by non-even key-values when using zap logging. 

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

Upstream ako-operator CI

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.