### PR TITLE
Cherry-pick fixes for log panic into release 1.5.3

### DIFF
--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
@@ -175,13 +175,13 @@ func (r *AKODeploymentConfigReconciler) reconcileNetworkSubnets(
 
 // 	added, err := r.AddUsableNetwork(r.aviClient, obj.Spec.CloudName, obj.Spec.DataNetwork.Name)
 // 	if err != nil {
-// 		log.Error(err, "Failed to add usable network", obj.Spec.DataNetwork.Name)
+// 		log.Error(err, "Failed to add usable network", "network", obj.Spec.DataNetwork.Name)
 // 		return ctrl.Result{}, err
 // 	}
 // 	if added {
-// 		log.Info("Added Usable Network", obj.Spec.DataNetwork.Name)
+// 		log.Info("Added Usable Network", "network", obj.Spec.DataNetwork.Name)
 // 	} else {
-// 		log.Info("Network is already one of the cloud's usable network", obj.Spec.DataNetwork.Name)
+// 		log.Info("Network is already one of the cloud's usable network", "network", obj.Spec.DataNetwork.Name)
 // 	}
 // 	return ctrl.Result{}, nil
 // }

--- a/controllers/cluster/cluster_controller.go
+++ b/controllers/cluster/cluster_controller.go
@@ -107,7 +107,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 	matchedAkoDeploymentConfigs := make([]akoov1alpha1.AKODeploymentConfig, 0)
 	for _, akoDeploymentConfig := range akoDeploymentConfigs.Items {
 		if selector, err := metav1.LabelSelectorAsSelector(&akoDeploymentConfig.Spec.ClusterSelector); err != nil {
-			log.Error(err, "Failed to convert label sector to selector when matching ", cluster.Name, " with ", akoDeploymentConfig.Name)
+			log.Error(err, "Failed to convert label sector to selector when matching ", "cluster", cluster.Name, " with ", akoDeploymentConfig.Name)
 		} else if selector.Matches(labels.Set(clusterLabels)) {
 			log.Info("Cluster ", cluster.Name, " is selected by", "Akodeploymentconfig", (akoDeploymentConfig.Namespace + "/" + akoDeploymentConfig.Name))
 			matchedAkoDeploymentConfigs = append(matchedAkoDeploymentConfigs, akoDeploymentConfig)
@@ -130,7 +130,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 
 	// Removing add on secret and its associated resources for a AKO
 	if _, err := r.deleteAddonSecret(ctx, log, cluster); err != nil {
-		log.Error(err, "Failed to remove secret", cluster.Name)
+		log.Error(err, "Failed to remove secret", "secret", cluster.Name)
 		return res, err
 	}
 

--- a/controllers/configmap/configmap_controller.go
+++ b/controllers/configmap/configmap_controller.go
@@ -121,13 +121,13 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	for _, vipNetwork := range vipNetworkList {
 		added, err := r.AddUsableNetwork(r.aviClient, cloudName, vipNetwork.NetworkName)
 		if err != nil {
-			log.Error(err, "Failed to add usable network", vipNetwork.NetworkName)
+			log.Error(err, "Failed to add usable network", "network", vipNetwork.NetworkName)
 			return ctrl.Result{}, err
 		}
 		if added {
-			log.Info("Added Usable Network", vipNetwork.NetworkName)
+			log.Info("Added Usable Network", "network", vipNetwork.NetworkName)
 		} else {
-			log.Info("Network is already one of the cloud's usable network", vipNetwork.NetworkName)
+			log.Info("Network is already one of the cloud's usable network", "network", vipNetwork.NetworkName)
 		}
 	}
 	return ctrl.Result{}, nil

--- a/pkg/controller-runtime/handlers/cluster_for_akodeploymentconfig_handler.go
+++ b/pkg/controller-runtime/handlers/cluster_for_akodeploymentconfig_handler.go
@@ -83,7 +83,7 @@ func ListADCsForCluster(
 			logger.V(3).Info("Cluster selected by non-default AKODeploymentConfig, skip default one")
 			continue
 		} else if selector.Matches(labels.Set(cluster.GetLabels())) {
-			logger.V(3).Info("Found matching AKODeploymentConfig", akoDeploymentConfig.Namespace+"/"+akoDeploymentConfig.Name)
+			logger.V(3).Info("Found matching AKODeploymentConfig", "adc", akoDeploymentConfig.Namespace+"/"+akoDeploymentConfig.Name)
 			adcForCluster = append(adcForCluster, akoDeploymentConfig)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry-pick fixes for log panic into release 1.5.3

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Cherry-pick fixes for log panic into release 1.5.3
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.