### PR TITLE
Fix the logic that adds skip-default-adc label, when the cluster is selected by a customized ADC.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PUBLISH?=publish
 BUILD_VERSION ?= $(shell git describe --always --match "v*" | sed 's/v//')
 
 # TKG Version
-TKG_VERSION ?= v1.6.0+vmware.8
+TKG_VERSION ?= v1.6.0+vmware.9
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_cluster_phase.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_cluster_phase.go
@@ -6,12 +6,10 @@ package akodeploymentconfig
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/controllers/akodeploymentconfig/cluster"
 	"github.com/vmware-samples/load-balancer-operator-for-kubernetes/controllers/akodeploymentconfig/phases"
 	controllerruntime "github.com/vmware-samples/load-balancer-operator-for-kubernetes/pkg/controller-runtime"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/go-logr/logr"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,12 +91,9 @@ func (r *AKODeploymentConfigReconciler) applyClusterLabel(
 	} else {
 		log.Info("Label already applied to cluster", "label", akoov1alpha1.AviClusterLabel)
 	}
-	selector, err := metav1.LabelSelectorAsSelector(&obj.Spec.ClusterSelector)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	// cluster selected by AKODeploymentConfig with selectors
-	if !selector.Empty() {
+	// When the cluster is selected by this AKODeploymentConfig, but its is not install-ako-for-all,
+	// this indicates that the cluster is managed by a customized ADC and the default ADC shall be skipped.
+	if obj.Name != akoov1alpha1.WorkloadClusterAkoDeploymentConfig {
 		cluster.Labels[akoov1alpha1.AviClusterSelectedLabel] = ""
 	}
 	// Always set avi label on managed cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

When the cluster is selected by a customized ADC (a.k.a not `install-ako-for-all`), the cluster should be labelled with `networking.tkg.tanzu.vmware.com/avi-skip-default-adc`. This indicates that the customized ADC should be applied over the default one.

Previously, the logic is wrong for determining whether an ADC is default or not. It wrongly assumes that a customized ADC always has non-empty `clusterSelector` and a default one has empty `clusterSelector`. But it doesn't hold true anymore with the introduction of `AVI_LABELS`.


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Fix the logic that adds skip-default-adc label, when the cluster is selected by a customized ADC.
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.